### PR TITLE
Update to use an alpine docker version of hugo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang
+FROM woahbase/alpine-hugo
 
-RUN mkdir $HOME/src && \
-    cd $HOME/src && \
-    git clone https://github.com/gohugoio/hugo.git && \
-    cd hugo && \
-    go install
+# RUN mkdir $HOME/src && \
+#     cd $HOME/src && \
+#     git clone https://github.com/gohugoio/hugo.git && \
+#     cd hugo && \
+#     go install
 
 RUN mkdir /app
 


### PR DESCRIPTION
Reduced size of the docker base hugo image to less then 200 M